### PR TITLE
Update vans_busses.json

### DIFF
--- a/data/mods/Magiclysm/vehicles/vans_busses.json
+++ b/data/mods/Magiclysm/vehicles/vans_busses.json
@@ -57,7 +57,7 @@
       { "x": 2, "y": 0, "part": "frame_orichalcum_horizontal" },
       { "x": 2, "y": 0, "part": "hdhalfboard_horizontal_2" },
       { "x": 2, "y": 0, "part": "plating_steel" },
-      { "x": 2, "y": 1, "part": "hdframe_cover" },
+      { "x": 2, "y": 1, "part": "frame_orichalcum_horizontal" },
       { "x": 2, "y": 1, "part": "hdhalfboard_horizontal_2" },
       { "x": 2, "y": 1, "part": "plating_steel" },
       { "x": 2, "y": 2, "part": "frame_orichalcum_horizontal" },


### PR DESCRIPTION
The Security Van had an errant HD frame that should likely have been an orichalcum one. Just an oversight, most likely.